### PR TITLE
Fix app crash from truncated models.py

### DIFF
--- a/models.py
+++ b/models.py
@@ -322,4 +322,4 @@ def log_activity(action_type, description, user_name=None):
         print(log_str, flush=True)
     except Exception as e:
         db.session.rollback()
-        print(f
+        print(f"Error logging activity: {e}", flush=True)


### PR DESCRIPTION
## Summary
- Restores the truncated `log_activity` print in `models.py` that caused a SyntaxError on import
- That crash stopped Gunicorn from starting, which produced Cloudflare 502 / connection refused after the last update

## Test plan
- [ ] Docker image builds from main
- [ ] Container starts and listens on port 3000
- [ ] https://choresrewards.matathome.com loads